### PR TITLE
Created script to auto-populate /etc/tpm-luks.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,8 @@ dist_sbin_SCRIPTS=tpm-luks/tpm-luks-chain-hashes \
 	     tpm-luks/tpm-luks-gen-tgrub2-pcr-values \
 	     tpm-luks/tpm-luks-update \
 	     tpm-luks/tpm-luks-init \
-             tpm-luks/tpm-luks-command-hash.py
+         tpm-luks/tpm-luks-command-hash.py \
+         tpm-luks/tpm-luks-autogen-conf.py
 
 #yumpluginconfdir=/etc/yum/pluginconf.d
 #dist_yumpluginconf_SCRIPTS=yum/post-transaction-actions.conf

--- a/tpm-luks.spec.in
+++ b/tpm-luks.spec.in
@@ -7,7 +7,7 @@
 
 Name:		@PACKAGE@
 Version:	@VERSION@
-Release:	2
+Release:	3
 Summary:	Utility for storing a LUKS key using a TPM
 
 Group:		Security
@@ -21,7 +21,7 @@ BuildRequires:	automake autoconf libtool openssl-devel
 # for now we require an upstream tpm-tools and trousers, so don't add them
 # here so we can avoid --nodeps
 Requires:	cryptsetup dracut gawk coreutils grubby tpm-tools >= 1.3.9 trousers >= 0.3.9 trustedgrub2 >= 1.4.0 yum-plugin-post-transaction-actions
-
+Requires: 	python
 %description
 tpm-luks is a set of scripts to enable storage of a LUKS key in your TPM.
 
@@ -59,7 +59,15 @@ make install DESTDIR=$RPM_BUILD_ROOT
 #/usr/lib/yum-plugins/post-transaction-actions.py*
 %config /etc/tpm-luks.conf
 
+%post
+%{_sbindir}/tpm-luks-autogen-conf.py %{_sbindir}/tpm-luks-gen-tgrub2-pcr-values >> /etc/tpm-luks.conf
+
 %changelog
+* Mon Sep 26 2016 John Wallace <jrwallace2@gesinger.edu>
+- Updated to build on RHEL7
+- Using a (sealed) key file on boot partition instead of NVRAM
+- After installing, generates the /etc/tpm-luks.conf based on /etc/crypttab
+
 * Tue Apr 09 2013 Ryan Harper <ryanh@us.ibm.com>
 - Updated to build on F18
 

--- a/tpm-luks/tpm-luks-autogen-conf.py
+++ b/tpm-luks/tpm-luks-autogen-conf.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+hash_script="/sbin/tpm-luks-gen-tgrub2-pcr-values"
+import sys
+
+if len(sys.argv) > 1:
+	hash_script=sys.argv[1]
+
+if __name__ == "__main__":
+	
+	with open("/etc/crypttab") as f:
+		for l in f:
+			tl = l.strip()
+			if len(tl) > 0 and not tl.startswith("#"):
+				fields = tl.split()
+				
+				ask_boot = True
+				
+				if len(fields) >= 4:
+					opts = set(fields[3].lower().split(','))
+					if "noauto" in opts or "nofail" in opts:
+						ask_boot  = False
+				
+				if len(fields) >= 3:
+					passwd=fields[2].lower()
+					if not (passwd == "-" or passwd == "none"):
+						ask_boot = False
+				
+					
+				# something probably went horribly wrong if <2 fields, 
+				# or if we wouldn't ask for a passwd on boot, we don't
+				# want to use tpm-luks.  Otherwise, let's set up the string 
+				if len(fields) >= 2 and ask_boot:
+					name=fields[0]
+					dev_id=fields[1]
+					
+					print "%s:%s:%s" % (dev_id, ".key." + name, hash_script)
+			
+			# end parsing line
+		# end parsing crypttab
+	# end open crypttab		
+


### PR DESCRIPTION
Per Issue #2, created a script that will populate /etc/tpm-luks.conf on
install.  This means that if the tpm-luks package is installed as a
part of the ISO, then there is no need to generate a new initial ramdisk
and thus, the ONLY step to enable tpm-luks will be a simple "tpm-luks-init"

Bumped the release version in the RPM spec and added a changelog commit msg.
