### PR TITLE
Allow UUID in tpm-luks.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,8 @@ dist_sbin_SCRIPTS=tpm-luks/tpm-luks-chain-hashes \
 	     tpm-luks/tpm-luks-gen-tgrub2-pcr-values \
 	     tpm-luks/tpm-luks-update \
 	     tpm-luks/tpm-luks-init \
-             tpm-luks/tpm-luks-command-hash.py
+         tpm-luks/tpm-luks-command-hash.py \
+         tpm-luks/tpm-luks-autogen-conf.py
 
 #yumpluginconfdir=/etc/yum/pluginconf.d
 #dist_yumpluginconf_SCRIPTS=yum/post-transaction-actions.conf

--- a/tpm-luks.spec.in
+++ b/tpm-luks.spec.in
@@ -7,7 +7,7 @@
 
 Name:		@PACKAGE@
 Version:	@VERSION@
-Release:	2
+Release:	3
 Summary:	Utility for storing a LUKS key using a TPM
 
 Group:		Security
@@ -21,7 +21,7 @@ BuildRequires:	automake autoconf libtool openssl-devel
 # for now we require an upstream tpm-tools and trousers, so don't add them
 # here so we can avoid --nodeps
 Requires:	cryptsetup dracut gawk coreutils grubby tpm-tools >= 1.3.9 trousers >= 0.3.9 trustedgrub2 >= 1.4.0 yum-plugin-post-transaction-actions
-
+Requires: 	python
 %description
 tpm-luks is a set of scripts to enable storage of a LUKS key in your TPM.
 
@@ -59,7 +59,15 @@ make install DESTDIR=$RPM_BUILD_ROOT
 #/usr/lib/yum-plugins/post-transaction-actions.py*
 %config /etc/tpm-luks.conf
 
+%post
+%{_sbindir}/tpm-luks-autogen-conf.py %{_sbindir}/tpm-luks-gen-tgrub2-pcr-values >> /etc/tpm-luks.conf
+
 %changelog
+* Mon Sep 26 2016 John Wallace <jrwallace2@gesinger.edu>
+- Updated to build on RHEL7
+- Using a (sealed) key file on boot partition instead of NVRAM
+- After installing, generates the /etc/tpm-luks.conf based on /etc/crypttab
+
 * Tue Apr 09 2013 Ryan Harper <ryanh@us.ibm.com>
 - Updated to build on F18
 

--- a/tpm-luks.spec.in
+++ b/tpm-luks.spec.in
@@ -7,7 +7,7 @@
 
 Name:		@PACKAGE@
 Version:	@VERSION@
-Release:	3
+Release:	4
 Summary:	Utility for storing a LUKS key using a TPM
 
 Group:		Security
@@ -63,6 +63,10 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %{_sbindir}/tpm-luks-autogen-conf.py %{_sbindir}/tpm-luks-gen-tgrub2-pcr-values >> /etc/tpm-luks.conf
 
 %changelog
+* Tue Oct 04 2016 John Wallace <jrwallace2@geisinger.edu>
+- Allowed the use of "UUID=" notation in tpm-luks.conf
+- Inverted sealing and adding key to LUKS to avoid key space exhaustion
+
 * Mon Sep 26 2016 John Wallace <jrwallace2@gesinger.edu>
 - Updated to build on RHEL7
 - Using a (sealed) key file on boot partition instead of NVRAM

--- a/tpm-luks/tpm-luks
+++ b/tpm-luks/tpm-luks
@@ -112,7 +112,7 @@ function seal_key
 	touch $SEALED_KEY
 	chmod go-rwx $SEALED_KEY
 	tpm_sealdata ${SEAL_OPTS} -i ${KEY_IN} -o ${SEALED_KEY} -z
-	wipe_file ${KEY_IN}
+	return $?
 }
 
 
@@ -136,6 +136,7 @@ function luks_add_key
 
 	$CRYPTSETUP luksAddKey --key-slot ${KEY_SLOT} $DEVICE ${1}
 	SCRIPT_RC=$?
+	return $SCRIPT_RC
 }
 
 function usage
@@ -251,10 +252,17 @@ tpm_owned
 if [ "${ACTION}" == "create" ]; then
 	device_get
 	keyfile_generate
-	luks_add_key ${TMPFS_KEYFILE}
 	seal_key ${TMPFS_KEYFILE} ${KEYFILE_NAME}
-
-	#echo "Using NV index for device ${DEVICE}"
+	SEAL_RC=$?
+	if [ $SEAL_RC -eq 0 ]; then
+		luks_add_key ${TMPFS_KEYFILE}
+	else
+		echo "Could not seal keyfile, not adding key to LUKS"
+		SCRIPT_RC=21
+	fi
+	
+	wipe_file ${TMPFS_KEYFILE}
+	
 elif [ "${ACTION}" == "migrate" ]; then
 
 	TMPFS_KEYFILE=${TMPFS_MNT}/key
@@ -279,8 +287,15 @@ elif [ "${ACTION}" == "migrate" ]; then
 	fi
 
 	seal_key ${TMPFS_KEYFILE} ${KEYFILE_NAME}
+	SEAL_RC=$?
+	wipe_file ${TMPFS_KEYFILE}
+	if [ $SEAL_RC -eq 0 ]; then
+		echo "Successfully migrated ${KEYFILE_NAME}"
+	else
+		echo "Could not migrate ${KEYFILE_NAME}, error sealing new keyfile"
+		SCRIPT_RC=21
+	fi
 	
-	echo "Successfully migrated ${KEYFILE_NAME}"
 else
 	usage
 	exit_script 1

--- a/tpm-luks/tpm-luks-autogen-conf.py
+++ b/tpm-luks/tpm-luks-autogen-conf.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+hash_script="/sbin/tpm-luks-gen-tgrub2-pcr-values"
+import sys
+
+if len(sys.argv) > 1:
+	hash_script=sys.argv[1]
+
+if __name__ == "__main__":
+	
+	with open("/etc/crypttab") as f:
+		for l in f:
+			tl = l.strip()
+			if len(tl) > 0 and not tl.startswith("#"):
+				fields = tl.split()
+				
+				ask_boot = True
+				
+				if len(fields) >= 4:
+					opts = set(fields[3].lower().split(','))
+					if "noauto" in opts or "nofail" in opts:
+						ask_boot  = False
+				
+				if len(fields) >= 3:
+					passwd=fields[2].lower()
+					if not (passwd == "-" or passwd == "none"):
+						ask_boot = False
+				
+					
+				# something probably went horribly wrong if <2 fields, 
+				# or if we wouldn't ask for a passwd on boot, we don't
+				# want to use tpm-luks.  Otherwise, let's set up the string 
+				if len(fields) >= 2 and ask_boot:
+					name=fields[0]
+					dev_id=fields[1]
+					
+					print "%s:%s:%s" % (dev_id, ".key." + name, hash_script)
+			
+			# end parsing line
+		# end parsing crypttab
+	# end open crypttab		
+


### PR DESCRIPTION
Allows UUID in tpm-luks.conf and auto-populates the /etc/tpm-luks.conf script
